### PR TITLE
Add mdl shadername support

### DIFF
--- a/src/pm_mdl.c
+++ b/src/pm_mdl.c
@@ -24,6 +24,7 @@
 
 /* dependencies */
 #include "picointernal.h"
+#include <string.h>
 
 #define MDL_NUMVERTEXNORMALS 162
 
@@ -348,6 +349,15 @@ static void* _offset_to(void **buf, size_t size) {
 	return before;
 }
 
+static char* _make_texture_path(const char *in, char *out) {
+	memcpy(out, in, 256);
+	_pico_setfext(out, "");
+	strcat(out, "_img");
+	_pico_unixify(out);
+	out[255] = '\0';
+	return out;
+}
+
 /*
 _mdl_load()
 loads a quake mdl model file.
@@ -366,6 +376,7 @@ static picoModel_t *_mdl_load(PM_PARAMS_LOAD) {
 	mdl_vertex_t *ofsVerts = NULL;
 	mdl_frame_t *frame;
 	int i;
+	char texturePath[256];
 
 	/* -------------------------------------------------
 	mdl loading
@@ -481,7 +492,7 @@ static picoModel_t *_mdl_load(PM_PARAMS_LOAD) {
 		return NULL;
 	}
 
-	// PicoSetShaderName(picoShader, "");
+	PicoSetShaderName(picoShader, _make_texture_path(fileName, texturePath));
 
 	PicoSetSurfaceShader(picoSurface, picoShader);
 

--- a/tests/pm_mdl_tests.cpp
+++ b/tests/pm_mdl_tests.cpp
@@ -15,8 +15,8 @@ TEST_CASE("Should correctly parse simple mdl") {
 	picoSurface_t *surface = PicoGetModelSurface(model, 0);
 	int numShaders = PicoGetModelNumShaders(model);
 	REQUIRE(numShaders == 1);
-	// picoShader_t *shader = PicoGetSurfaceShader(surface);
-	// REQUIRE(std::string("myshader_1") == PicoGetShaderName(shader));
+	picoShader_t *shader = PicoGetSurfaceShader(surface);
+	REQUIRE(std::string("../tests/assets/model_img") == PicoGetShaderName(shader));
 	int numVerts = PicoGetSurfaceNumVertexes(surface);
 	REQUIRE(numVerts == 6);
 	int numInds = PicoGetSurfaceNumIndexes(surface);


### PR DESCRIPTION
MDL "textures" reside within the model itself, picomodel doesn't know how to carry bitmaps within its structure, so in order to have a possibility to texture the model once it will be placed in bsp by map compiler, here what we can do: compose a shadername based of mdl path, so path like `models/monster/boss.mdl` will be converted into shadername `models/monster/boss_img`, you can then link the right texture in a shader file through that name.